### PR TITLE
Add navigation and SmartDash dashboard screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,14 @@ android {
 
 dependencies {
 
+    testImplementation(libs.junit)
+    debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation(libs.androidx.ui.test.manifest)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -69,35 +77,18 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.locationdelegation)
     implementation(libs.androidx.benchmark.common)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
-
-    // Hilt Dependency Injection
+    implementation(libs.navigation.compose)
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
-
-    // Hilt Navigation for Compose
     implementation(libs.hilt.navigation.compose)
-
-    // Kotlin Serialization
     implementation(libs.kotlinx.serialization.json)
-
-    // Retrofit + OKHttp for Networking
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
     implementation(libs.retrofit.kotlinx.serialization.converter)
-
-    // Coroutines
     implementation(libs.kotlinx.coroutines.android)
-
-    // Play Services
     implementation(libs.play.services.location)
+
 
 }

--- a/app/src/main/java/com/netanel/smartdash/app/AppNavHost.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/AppNavHost.kt
@@ -1,0 +1,25 @@
+package com.netanel.smartdash.app
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.netanel.smartdash.feature_weather.ui.SmartDashScreen
+import com.netanel.smartdash.feature_weather.ui.WeatherViewModel
+
+@Composable
+fun AppNavHost(
+    navController: NavHostController
+) {
+    NavHost(navController = navController, startDestination = NavRoutes.Home.route) {
+
+        composable(route = NavRoutes.Home.route) {
+            // Home dashboard holding weather (for now)
+            val vm: WeatherViewModel = hiltViewModel()
+            SmartDashScreen(vm = vm /*, onWeatherClick = { navController.navigate(NavRoutes.WeatherDetails.route) } */)
+        }
+
+        // composable(NavRoutes.WeatherDetails.route) { WeatherDetailsScreen(...) }
+    }
+}

--- a/app/src/main/java/com/netanel/smartdash/app/MainActivity.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/MainActivity.kt
@@ -1,56 +1,23 @@
 package com.netanel.smartdash.app
 
-import android.Manifest
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.Text
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.netanel.smartdash.core.permissions.PermissionManager
-import com.netanel.smartdash.core.permissions.PermissionResult
+import androidx.navigation.compose.rememberNavController
 import com.netanel.smartdash.core.theme.SmartDashTheme
-import com.netanel.smartdash.feature_weather.ui.WeatherViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private lateinit var pm: PermissionManager
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        pm = PermissionManager.from(this)
 
         setContent {
-            val vm: WeatherViewModel = hiltViewModel()
-
-            val state by vm.state.collectAsState()
-
-            LaunchedEffect(Unit) {
-                when (pm.request(Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    PermissionResult.Granted -> vm.startLocationTracking()
-                    is PermissionResult.Denied,
-                    PermissionResult.DeniedPermanently -> vm.load(
-                        32.0800964,
-                        34.8243129
-                    ) // fallback
-                }
-            }
-
             SmartDashTheme {
-                when (val s = state) {
-                    is WeatherViewModel.UiState.Idle -> Text("Idle…")
-                    is WeatherViewModel.UiState.Loading -> Text("Loading…")
-                    is WeatherViewModel.UiState.Success ->
-                        Text("🌤 ${s.data.city}: ${s.data.temperatureC}°C, ${s.data.description}")
-
-                    is WeatherViewModel.UiState.Error -> Text("❌ ${s.message}")
-                }
+                val navController = rememberNavController()
+                AppNavHost(navController = navController)
             }
         }
     }
 }
-

--- a/app/src/main/java/com/netanel/smartdash/app/NavRoutes.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/NavRoutes.kt
@@ -1,0 +1,8 @@
+package com.netanel.smartdash.app
+
+sealed interface NavRoutes {
+    val route: String
+
+    data object Home : NavRoutes { override val route = "home" }
+    // data object WeatherDetails : NavRoutes { override val route = "weather/details" } // future
+}

--- a/app/src/main/java/com/netanel/smartdash/feature_weather/ui/SmartDashScreen.kt
+++ b/app/src/main/java/com/netanel/smartdash/feature_weather/ui/SmartDashScreen.kt
@@ -1,0 +1,180 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.netanel.smartdash.feature_weather.ui
+
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.netanel.smartdash.feature_weather.domain.model.WeatherNow
+
+/* ---------- Dashboard cell models ---------- */
+sealed interface DashCell { val key: String }
+
+/** Weather cell (first cell type) */
+data class WeatherCell(
+    val data: WeatherNow,
+    val onClick: () -> Unit
+) : DashCell {
+    override val key: String = "cell_weather" // stable key; keep unique per type/instance
+}
+
+/* ---------- Screen ---------- */
+@Composable
+fun SmartDashScreen(
+    vm: WeatherViewModel = hiltViewModel()
+) {
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    // Compose-native permission
+    val locationPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) vm.startLocationTracking()
+        else vm.load(32.0800964, 34.8243129) // fallback TLV
+    }
+    LaunchedEffect(Unit) { locationPermission.launch(Manifest.permission.ACCESS_FINE_LOCATION) }
+
+    // Stop location updates when leaving this screen
+    DisposableEffect(Unit) { onDispose { vm.stopLocationTracking() } }
+
+    Scaffold(
+        topBar = { SmallTopAppBar(title = { Text("SmartDash") }) }
+    ) { p ->
+        // Build cells for the list (for now, only weather)
+        val cells: List<DashCell> = when (val s = state) {
+            is WeatherViewModel.UiState.Success -> listOf(
+                WeatherCell(
+                    data = s.data,
+                    onClick = { /* TODO: navigate to weather details when added */ }
+                )
+            )
+            is WeatherViewModel.UiState.Error -> listOf(
+                // you could add a dedicated ErrorCell later; for now render as a single item via when()
+            )
+            else -> emptyList()
+        }
+
+        // LazyColumn that can host any cell type
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(p),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Loading/Idle placeholders
+            when (state) {
+                is WeatherViewModel.UiState.Idle,
+                is WeatherViewModel.UiState.Loading -> {
+                    item("loading") { LoadingCard() }
+                }
+                is WeatherViewModel.UiState.Error -> {
+                    val msg = (state as WeatherViewModel.UiState.Error).message
+                    item("error") { ErrorCard(message = msg, onRetry = { vm.refresh() }) }
+                }
+                else -> Unit
+            }
+
+            // Real cells
+            items(
+                items = cells,
+                key = { it.key }
+            ) { cell ->
+                when (cell) {
+                    is WeatherCell -> WeatherCard(
+                        modifier = Modifier,
+                        data = cell.data,
+                        onClick = cell.onClick
+                    )
+                    // Add more cell renderers here (e.g., NewsCell, TasksCell, BalanceCell, etc.)
+                }
+            }
+
+            // Example footer actions
+            if (state is WeatherViewModel.UiState.Success) {
+                item("actions_refresh") {
+                    OutlinedButton(onClick = { vm.refresh() }) { Text("Refresh") }
+                }
+            }
+        }
+    }
+}
+
+/* ---------- Cards ---------- */
+
+@Composable
+private fun LoadingCard() {
+    Card(shape = MaterialTheme.shapes.medium) {
+        // simple centered loader; you can replace with shimmer later
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp)
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+}
+
+@Composable
+private fun ErrorCard(message: String, onRetry: () -> Unit) {
+    Card(shape = MaterialTheme.shapes.medium) {
+        androidx.compose.foundation.layout.Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("Oops: $message", style = MaterialTheme.typography.bodyMedium)
+            OutlinedButton(onClick = onRetry) { Text("Try again") }
+        }
+    }
+}
+
+@Composable
+fun WeatherCard(
+    modifier: Modifier = Modifier,
+    data: WeatherNow,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        onClick = onClick // ✅ use Card's onClick instead of Modifier.clickable
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = data.city,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "${data.temperatureC ?: "-"}°C",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = data.description.orEmpty(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/netanel/smartdash/feature_weather/ui/WeatherViewModel.kt
+++ b/app/src/main/java/com/netanel/smartdash/feature_weather/ui/WeatherViewModel.kt
@@ -7,10 +7,15 @@ import com.netanel.smartdash.core.network.ApiResult
 import com.netanel.smartdash.feature_weather.domain.model.WeatherNow
 import com.netanel.smartdash.feature_weather.domain.usecase.GetCurrentWeatherByCoords
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+import kotlin.math.pow
+import kotlin.math.round
 
 @HiltViewModel
 class WeatherViewModel @Inject constructor(
@@ -28,32 +33,50 @@ class WeatherViewModel @Inject constructor(
     private val _state = MutableStateFlow<UiState>(UiState.Idle)
     val state: StateFlow<UiState> = _state
 
-    /**
-     * Fetch weather once for given coords.
-     */
+    private var lastCoords: Pair<Double, Double>? = null
+    private var trackingJob: Job? = null
+
+    /** One-shot fetch for provided coords. */
     fun load(lat: Double, lon: Double) {
+        lastCoords = lat to lon
         _state.value = UiState.Loading
         viewModelScope.launch {
-            when (val res = getWeather(lat, lon)) {
-                is ApiResult.Success -> _state.value = UiState.Success(res.value)
-                is ApiResult.HttpError -> _state.value = UiState.Error("HTTP ${res.code}")
-                is ApiResult.NetworkError -> _state.value = UiState.Error("Network error")
-                is ApiResult.SerializationError -> _state.value = UiState.Error("Parse error")
-                is ApiResult.UnknownError -> _state.value = UiState.Error("Unknown error")
+            _state.value = when (val res = getWeather(lat, lon)) {
+                is ApiResult.Success -> UiState.Success(res.value)
+                is ApiResult.HttpError -> UiState.Error("HTTP ${res.code}")
+                is ApiResult.NetworkError -> UiState.Error("Network error")
+                is ApiResult.SerializationError -> UiState.Error("Parse error")
+                is ApiResult.UnknownError -> UiState.Error("Unknown error")
             }
         }
     }
 
+    /** Refresh using last known coords (used by the Home/SmartDash screen). */
+    fun refresh() {
+        val (lat, lon) = lastCoords ?: return
+        load(lat, lon)
+    }
+
     /**
-     * Start continuous location tracking and fetch weather on each update.
-     * Call only after permissions are granted.
+     * Start polling current location and fetch weather every [pollMs].
+     * Defaults to 6 minutes (360_000 ms). Call only after permissions are granted.
      */
-    fun startLocationTracking() {
+    fun startLocationTracking(pollMs: Long = 360_000L) {
+        if (trackingJob?.isActive == true) return
         _state.value = UiState.Loading
-        viewModelScope.launch {
-            locationProvider.pollLocation().collect { loc ->
-                loc?.let {
-                    when (val res = getWeather(loc.latitude, loc.longitude)) {
+
+        trackingJob = viewModelScope.launch {
+            locationProvider
+                .pollLocation(intervalMs = pollMs)
+                // reduce jitter so tiny GPS drift doesn't spam the API
+                .map { loc -> loc?.let { roundCoords(it.latitude, it.longitude, 4) } }
+                .distinctUntilChanged()
+                .collect { coords ->
+                    coords ?: return@collect
+                    val (lat, lon) = coords
+                    lastCoords = lat to lon
+
+                    when (val res = getWeather(lat, lon)) {
                         is ApiResult.Success -> _state.value = UiState.Success(res.value)
                         is ApiResult.HttpError -> _state.value = UiState.Error("HTTP ${res.code}")
                         is ApiResult.NetworkError -> _state.value = UiState.Error("Network error")
@@ -61,7 +84,20 @@ class WeatherViewModel @Inject constructor(
                         is ApiResult.UnknownError -> _state.value = UiState.Error("Unknown error")
                     }
                 }
-            }
         }
+    }
+
+    /** Stop polling (called from screen's onDispose). */
+    fun stopLocationTracking() {
+        trackingJob?.cancel()
+        trackingJob = null
+    }
+
+    private fun roundCoords(lat: Double, lon: Double, decimals: Int): Pair<Double, Double> {
+        fun r(v: Double): Double {
+            val m = 10.0.pow(decimals)
+            return round(v * m) / m
+        }
+        return r(lat) to r(lon)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,9 @@ composeBom = "2024.04.01"
 # Play Services
 play-services-location = "21.2.0"
 
+# Navigation
+navigation = "2.8.0"
+
 # DI
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
@@ -48,28 +51,19 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-
-# Hilt
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
-
-# Serialization
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 retrofit-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "jake-retrofit-kotlinx" }
-
-# Networking
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
-
-# Play Services
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "play-services-location" }
 locationdelegation = { group = "com.google.androidbrowserhelper", name = "locationdelegation", version.ref = "locationdelegation" }
 androidx-benchmark-common = { group = "androidx.benchmark", name = "benchmark-common", version.ref = "benchmarkCommon" }
-
-#Coroutines
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 
 [plugins]


### PR DESCRIPTION
Introduces Jetpack Navigation Compose to the app, refactors MainActivity to use a NavHost, and adds AppNavHost and NavRoutes for navigation structure. Implements SmartDashScreen as the new dashboard UI, moving weather logic and permission handling into a composable. WeatherViewModel is updated to support location polling, refresh, and stop tracking. Updates dependencies and versions to support navigation.