### PR TITLE
Refresh dashboard visuals and theme

### DIFF
--- a/app/src/main/java/com/netanel/smartdash/app/AppNavHost.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/AppNavHost.kt
@@ -1,5 +1,6 @@
 package com.netanel.smartdash.app
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -9,13 +10,14 @@ import com.netanel.smartdash.feature_weather.ui.WeatherViewModel
 
 @Composable
 fun AppNavHost(
+    paddingValues: PaddingValues,
     navController: NavHostController
 ) {
     NavHost(navController = navController, startDestination = NavRoutes.Home.route) {
 
         composable(route = NavRoutes.Home.route) {
             // Home dashboard holding weather (for now)
-            SmartDashScreen()
+            SmartDashScreen(paddingValues)
         }
 
         // composable(NavRoutes.WeatherDetails.route) { WeatherDetailsScreen(...) }

--- a/app/src/main/java/com/netanel/smartdash/app/MainActivity.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/MainActivity.kt
@@ -3,6 +3,12 @@ package com.netanel.smartdash.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.navigation.compose.rememberNavController
 import com.netanel.smartdash.core.theme.SmartDashTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -10,13 +16,30 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
             SmartDashTheme {
-                val navController = rememberNavController()
-                AppNavHost(navController = navController)
+                Scaffold(topBar = {
+                    CenterAlignedTopAppBar(
+                        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            titleContentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        title = {
+                            Text(
+                                text = "SmartDash",
+                                style = MaterialTheme.typography.titleLarge
+                            )
+                        }
+                    )
+                },) { paddingValues ->
+                    val navController = rememberNavController()
+                    AppNavHost(paddingValues, navController = navController)
+                }
+
             }
         }
     }

--- a/app/src/main/java/com/netanel/smartdash/app/SmartDashScreen.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/SmartDashScreen.kt
@@ -59,6 +59,7 @@ data class TopCoinsCell(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SmartDashScreen(
+    p: PaddingValues,
     weatherVm: WeatherViewModel = hiltViewModel(),
     coinsVm: TopCoinsViewModel = hiltViewModel()
 ) {
@@ -77,23 +78,7 @@ fun SmartDashScreen(
     // Stop location updates when leaving this screen
     DisposableEffect(Unit) { onDispose { weatherVm.stopLocationTracking() } }
 
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            CenterAlignedTopAppBar(
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface
-                ),
-                title = {
-                    Text(
-                        text = "SmartDash",
-                        style = MaterialTheme.typography.titleLarge
-                    )
-                }
-            )
-        }
-    ) { p ->
+
         val cells: List<DashCell> = buildList {
             if (weatherState is WeatherViewModel.UiState.Success) {
                 val data = (weatherState as WeatherViewModel.UiState.Success).data
@@ -193,7 +178,7 @@ fun SmartDashScreen(
                     }
                 }
             }
-        }
+
     }
 }
 

--- a/app/src/main/java/com/netanel/smartdash/app/SmartDashScreen.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/SmartDashScreen.kt
@@ -3,17 +3,21 @@ package com.netanel.smartdash.app
 import android.Manifest
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallTopAppBar
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -74,7 +78,21 @@ fun SmartDashScreen(
     DisposableEffect(Unit) { onDispose { weatherVm.stopLocationTracking() } }
 
     Scaffold(
-        topBar = { SmallTopAppBar(title = { Text("SmartDash") }) }
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            CenterAlignedTopAppBar(
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                ),
+                title = {
+                    Text(
+                        text = "SmartDash",
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                }
+            )
+        }
     ) { p ->
         val cells: List<DashCell> = buildList {
             if (weatherState is WeatherViewModel.UiState.Success) {
@@ -109,9 +127,10 @@ fun SmartDashScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
                 .padding(p),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             // Loading/Idle placeholders
             if (showInitialLoading) {
@@ -155,13 +174,23 @@ fun SmartDashScreen(
             // Example footer actions
             if (weatherState is WeatherViewModel.UiState.Success) {
                 item("actions_refresh_weather") {
-                    OutlinedButton(onClick = { weatherVm.refresh() }) { Text("Refresh weather") }
+                    FilledTonalButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { weatherVm.refresh() }
+                    ) {
+                        Text("Refresh weather")
+                    }
                 }
             }
 
             if (coinsState is TopCoinsViewModel.UiState.Success) {
                 item("actions_refresh_coins") {
-                    OutlinedButton(onClick = { coinsVm.refresh() }) { Text("Refresh coins") }
+                    FilledTonalButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { coinsVm.refresh() }
+                    ) {
+                        Text("Refresh coins")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/netanel/smartdash/app/ui/ErrorCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/ui/ErrorCard.kt
@@ -24,7 +24,7 @@ fun ErrorCard(message: String, onRetry: () -> Unit) {
             containerColor = MaterialTheme.colorScheme.errorContainer,
             contentColor = MaterialTheme.colorScheme.onErrorContainer
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/netanel/smartdash/app/ui/ErrorCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/ui/ErrorCard.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,15 +17,39 @@ import androidx.compose.ui.unit.dp
 
 
 @Composable
- fun ErrorCard(message: String, onRetry: () -> Unit) {
-    Card(shape = MaterialTheme.shapes.medium) {
+fun ErrorCard(message: String, onRetry: () -> Unit) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
         Column(
-            modifier = Modifier.padding(16.dp).fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.Start
         ) {
-            Text("Oops: $message", style = MaterialTheme.typography.bodyMedium)
-            OutlinedButton(onClick = onRetry) { Text("Try again") }
+            Text(
+                text = "We couldn't refresh",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            FilledTonalButton(
+                colors = ButtonDefaults.filledTonalButtonColors(
+                    containerColor = MaterialTheme.colorScheme.onErrorContainer,
+                    contentColor = MaterialTheme.colorScheme.errorContainer
+                ),
+                onClick = onRetry
+            ) {
+                Text("Try again")
+            }
         }
     }
 }

--- a/app/src/main/java/com/netanel/smartdash/app/ui/LoadingCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/app/ui/LoadingCard.kt
@@ -1,26 +1,39 @@
 package com.netanel.smartdash.app.ui
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun LoadingCard() {
-    Card(shape = MaterialTheme.shapes.medium) {
-        // simple centered loader; you can replace with shimmer later
-        Box(
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(
             modifier = Modifier
-                .wrapContentSize(Alignment.Center)
-                .padding(24.dp)
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            CircularProgressIndicator()
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            Text(
+                text = "Loading your dashboard…",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/com/netanel/smartdash/core/theme/Color.kt
+++ b/app/src/main/java/com/netanel/smartdash/core/theme/Color.kt
@@ -2,10 +2,17 @@ package com.netanel.smartdash.core.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Primary blues used across the dashboard
+val OceanBlue = Color(0xFF3366FF)
+val DeepIndigo = Color(0xFF1D2A53)
+val MistBlue = Color(0xFFE4ECFF)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+// Accent colors for highlights and feedback
+val AquaTeal = Color(0xFF0FB9B1)
+val GoldenSun = Color(0xFFFFB547)
+val CoralError = Color(0xFFFF5F5F)
+
+// Neutral surfaces
+val SlateInk = Color(0xFF111827)
+val SoftSlate = Color(0xFF1F2937)
+val CloudGray = Color(0xFFF5F7FB)

--- a/app/src/main/java/com/netanel/smartdash/core/theme/Theme.kt
+++ b/app/src/main/java/com/netanel/smartdash/core/theme/Theme.kt
@@ -8,35 +8,56 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = OceanBlue,
+    onPrimary = Color.Black,
+    primaryContainer = DeepIndigo,
+    onPrimaryContainer = Color.White,
+    secondary = AquaTeal,
+    onSecondary = Color.Black,
+    secondaryContainer = DeepIndigo,
+    onSecondaryContainer = Color.White,
+    tertiary = GoldenSun,
+    onTertiary = Color.Black,
+    background = SoftSlate,
+    onBackground = Color.White,
+    surface = SoftSlate,
+    onSurface = Color.White,
+    surfaceVariant = SlateInk,
+    onSurfaceVariant = MistBlue,
+    error = CoralError,
+    onError = Color.Black
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
+    primary = OceanBlue,
     onPrimary = Color.White,
+    primaryContainer = MistBlue,
+    onPrimaryContainer = DeepIndigo,
+    secondary = AquaTeal,
     onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    secondaryContainer = AquaTeal.copy(alpha = 0.12f),
+    onSecondaryContainer = AquaTeal,
+    tertiary = GoldenSun,
+    onTertiary = Color.Black,
+    background = CloudGray,
+    onBackground = SlateInk,
+    surface = Color.White,
+    onSurface = SlateInk,
+    surfaceVariant = MistBlue,
+    onSurfaceVariant = DeepIndigo,
+    error = CoralError,
+    onError = Color.White
 )
 
 @Composable
 fun SmartDashTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    // We keep dynamic colors opt-in so the custom palette stays consistent.
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {

--- a/app/src/main/java/com/netanel/smartdash/feature_coins/ui/TopCoinsCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/feature_coins/ui/TopCoinsCard.kt
@@ -52,7 +52,7 @@ fun TopCoinsCard(
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
-                    text = "Market movers",
+                    text = "Crypto Market",
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/netanel/smartdash/feature_coins/ui/TopCoinsCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/feature_coins/ui/TopCoinsCard.kt
@@ -3,20 +3,21 @@ package com.netanel.smartdash.feature_coins.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.netanel.smartdash.feature_coins.domain.model.TopCoin
 import java.text.NumberFormat
@@ -36,72 +37,161 @@ fun TopCoinsCard(
         }
     }
 
+    val topCoins = coins.take(5)
+
     Card(
         modifier = modifier,
         onClick = onClick,
-        shape = MaterialTheme.shapes.medium,
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        shape = MaterialTheme.shapes.large,
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(
-                text = "Top Crypto (24h)",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = "Market movers",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "Top crypto • 24h",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
 
-            coins.take(5).forEachIndexed { index, coin ->
-                if (index > 0) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                }
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
+            topCoins.firstOrNull()?.let { leader ->
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    shape = MaterialTheme.shapes.large
                 ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                        Text(
-                            text = "${coin.marketCapRank ?: index + 1}. ${coin.name}",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Text(
-                            text = coin.symbol,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-
-                    Column(horizontalAlignment = Alignment.End) {
-                        val priceText = coin.priceUsd?.let { priceFormatter.format(it) } ?: "-"
-                        Text(
-                            text = priceText,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-
-                        val change = coin.changePercent24h
-                        val changeColor: Color = when {
-                            change == null -> MaterialTheme.colorScheme.onSurfaceVariant
-                            change >= 0.0 -> MaterialTheme.colorScheme.tertiary
-                            else -> MaterialTheme.colorScheme.error
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 18.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                            Text(
+                                text = "${leader.marketCapRank ?: 1}. ${leader.name}",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = leader.symbol.uppercase(Locale.getDefault()),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                            )
                         }
-                        val changeText = change?.let {
-                            val pct = percentFormatter.format(it / 100.0)
-                            if (it >= 0) "+$pct" else pct
-                        } ?: "—"
-                        Text(
-                            text = changeText,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = changeColor,
-                            fontWeight = FontWeight.Medium
-                        )
+
+                        Column(
+                            horizontalAlignment = Alignment.End,
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            val priceText = leader.priceUsd?.let { priceFormatter.format(it) } ?: "—"
+                            Text(
+                                text = priceText,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+
+                            val changeColor = leader.changePercent24h.changeColor(MaterialTheme.colorScheme)
+                            val changeText = leader.changePercent24h.formatChange(percentFormatter)
+                            Text(
+                                text = changeText,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = changeColor,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
                     }
                 }
             }
+
+            if (topCoins.size > 1) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    topCoins.drop(1).forEachIndexed { index, coin ->
+                        Surface(
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                            contentColor = MaterialTheme.colorScheme.onSurface,
+                            shape = MaterialTheme.shapes.medium
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    Text(
+                                        text = "${coin.marketCapRank ?: index + 2}. ${coin.name}",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = FontWeight.Medium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    Text(
+                                        text = coin.symbol.uppercase(Locale.getDefault()),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+
+                                Column(
+                                    horizontalAlignment = Alignment.End,
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    val priceText = coin.priceUsd?.let { priceFormatter.format(it) } ?: "—"
+                                    Text(
+                                        text = priceText,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = FontWeight.SemiBold
+                                    )
+
+                                    val changeColor = coin.changePercent24h.changeColor(MaterialTheme.colorScheme)
+                                    val changeText = coin.changePercent24h.formatChange(percentFormatter)
+                                    Text(
+                                        text = changeText,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = changeColor,
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Text(
+                text = "Tap to refresh prices",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary
+            )
         }
     }
+}
+
+private fun Double?.changeColor(scheme: ColorScheme): Color {
+    return when {
+        this == null -> scheme.onSurfaceVariant
+        this >= 0.0 -> scheme.tertiary
+        else -> scheme.error
+    }
+}
+
+private fun Double?.formatChange(formatter: NumberFormat): String {
+    return this?.let {
+        val pct = formatter.format(it / 100.0)
+        if (it >= 0) "+$pct" else pct
+    } ?: "—"
 }

--- a/app/src/main/java/com/netanel/smartdash/feature_weather/ui/WeatherCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/feature_weather/ui/WeatherCard.kt
@@ -50,7 +50,7 @@ fun WeatherCard(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 Text(
-                    text = "Current weather",
+                    text = "Current Weather",
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f)
                 )

--- a/app/src/main/java/com/netanel/smartdash/feature_weather/ui/WeatherCard.kt
+++ b/app/src/main/java/com/netanel/smartdash/feature_weather/ui/WeatherCard.kt
@@ -1,16 +1,22 @@
 package com.netanel.smartdash.feature_weather.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.netanel.smartdash.feature_weather.domain.model.WeatherNow
 
@@ -20,33 +26,73 @@ fun WeatherCard(
     data: WeatherNow,
     onClick: () -> Unit
 ) {
+    val gradient = Brush.linearGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primary,
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+            MaterialTheme.colorScheme.secondary
+        )
+    )
     Card(
         modifier = modifier,
-        shape = MaterialTheme.shapes.medium,
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-        onClick = onClick
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
     ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+        Box(
+            modifier = Modifier
+                .background(gradient)
+                .padding(20.dp)
         ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "Current weather",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f)
+                )
 
-            Text(text = "Weather Now", color = Color.Black)
-            Text(
-                text = data.city,
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Text(
-                text = "${data.temperatureC ?: "-"}°C",
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.primary
-            )
-            Text(
-                text = data.description.orEmpty(),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text(
+                            text = data.city,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                        Text(
+                            text = data.description.orEmpty().ifEmpty { "Updating forecast" },
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
+                        )
+                    }
+
+                    Text(
+                        text = data.temperatureC?.let { "$it°" } ?: "—",
+                        style = MaterialTheme.typography.displaySmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+
+                Surface(
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.12f),
+                    shape = MaterialTheme.shapes.medium
+                ) {
+                    Text(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                        text = "Tap for live details",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f)
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the default Compose purple palette with a custom SmartDash color system and disable dynamic colors for a consistent look
- refresh the SmartDash scaffold with a centered top app bar, themed spacing, and full-width refresh actions
- redesign the weather, coins, loading, and error cards so each cell matches its content and the new color system

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce65df418832e9d5bf378e7be6714